### PR TITLE
feat: add lint and create-sentry-release workflows

### DIFF
--- a/.github/workflows/create-sentry-release.yml
+++ b/.github/workflows/create-sentry-release.yml
@@ -1,0 +1,29 @@
+name: Create a Sentry release
+on:
+  workflow_call:
+    inputs:
+      target:
+        required: false
+        default: '16'
+        type: string
+      project:
+        required: true
+        type: string
+    secrets: inherit
+jobs:
+  create-sentry-release:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ inputs.target }}
+          cache: 'yarn'
+      - run: yarn
+      - run: yarn build
+      - name: Create a Sentry release
+        uses: getsentry/action-release@v1.4.1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ inputs.project }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,21 @@
+name: Lint
+on:
+  workflow_call:
+    inputs:
+      target:
+        required: false
+        default: '16'
+        type: string
+    secrets: inherit
+jobs:
+  lint:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ inputs.target }}
+          cache: 'yarn'
+      - run: yarn
+      - run: yarn lint
+      - run: yarn typecheck

--- a/README.md
+++ b/README.md
@@ -1,3 +1,57 @@
 # Actions
 
-This repository centralize all Github actions workflows used by @snapshot-lasb, for easier reuse and maintenance
+This repository centralize all Github actions workflows used by @snapshot-labs, for easier reuse, maintenance and reduce code duplication.
+
+## Usage
+
+### Lint
+
+This workflow trigger the lint (`yarn lint`) and typecheck (`yarn typecheck`) tasks.
+
+Install it in your project by creating the file `.github/workflows/lint.yml`, with the following content 
+
+```yaml 
+name: Lint
+on: [push]
+jobs:
+  lint:
+    uses: snapshot-labs/actions/.github/workflows/lint.yml@main
+```
+
+If you want to run it on different node versions 
+
+```yaml 
+
+```yaml 
+name: Lint
+on: [push]
+jobs:
+  lint:
+  	strategy:
+      matrix:
+        target: ['16', '18'] # Set your desired node versions (Default is 16)
+    uses: snapshot-labs/actions/.github/workflows/lint.yml@main
+    with:
+      target: ${{ matrix.target }}
+```
+
+### Create a sentry release
+
+This workflow trigger a task to upload the sourcemaps to Sentry, then create a Sentry release.
+
+**Ensure your build task (`yarn build`) is configured to output sourcemaps.**
+
+
+Install it in your project by creating the file `.github/workflows/lint.yml`, with the following content 
+
+```yaml 
+name: Create a Sentry release
+on: [push]
+jobs:
+  lint:
+    uses: snapshot-labs/actions/.github/workflows/create-sentry-release.yml@main
+    with:
+      project: YOUR-SENTRY-PROJECT-NAME
+      # You can optionally add the following line to set the node version (Default is 16)
+      # target: '16'
+```


### PR DESCRIPTION
Add basic `lint` and `create-sentry-release` shareable workflows, to be reused other projects in the org.