### PR TITLE
chore: enforce `--frozen-lockfile` when running yarn install

### DIFF
--- a/.github/workflows/create-sentry-release.yml
+++ b/.github/workflows/create-sentry-release.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: ${{ inputs.target }}
           cache: 'yarn'
-      - run: yarn
+      - run: yarn install --frozen-lockfile
       - run: yarn build
       - name: Create a Sentry release
         uses: getsentry/action-release@v1.4.1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,6 @@ jobs:
         with:
           node-version: ${{ inputs.target }}
           cache: 'yarn'
-      - run: yarn
+      - run: yarn install --frozen-lockfile
       - run: yarn lint
       - run: yarn typecheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           mysql -uroot -proot ${{ inputs.mysql_database_name }} < ${{ inputs.mysql_schema_path }}
           mysql -uroot -proot -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';"
           mysql -uroot -proot -e "FLUSH PRIVILEGES;"
-      - run: yarn
+      - run: yarn install --frozen-lockfile
       - run: yarn test
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

`yarn install` tasks within workflows are not using the `--frozen-lockfile` option. This can lead to CI using different versions of dependencies in some case.

From yarn doc:
> If you need reproducible dependencies, which is usually the case with the continuous integration systems, you should pass --frozen-lockfile flag.

## 💊 Fixes / Solution

Pass `--frozen-lockfile` to ensure CI will always use same dependencies version.

## 🚧 Changes

- Add the `-frozen-lockfile` option to all `yarn install` commands


## 🛠️ Tests

- N/A