### PR TITLE
fix: use custom redis setup actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,9 @@ on:
         required: false
         type: string
         default: 'src/helpers/schema.sql'
-      redis:
+      redis-version:
         required: false
-        type: boolean
-        default: false
+        type: string
       dotenv_vars:
         required: false
         type: string
@@ -27,15 +26,6 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     timeout-minutes: 10
-
-    services:
-      redis:
-        image: ${{ inputs.redis && 'redis' || '' }}
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
 
     steps:
       - uses: actions/checkout@v3
@@ -52,6 +42,12 @@ jobs:
           mysql -uroot -proot ${{ inputs.mysql_database_name }} < ${{ inputs.mysql_schema_path }}
           mysql -uroot -proot -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';"
           mysql -uroot -proot -e "FLUSH PRIVILEGES;"
+
+      - name: Setup Redis
+        if: ${{ inputs.redis-version }}
+        uses: supercharge/redis-github-action@1.7.0
+        with:
+          redis-version: ${{ inputs.redis-version }}
 
       - name: Yarn install
         run: yarn install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,14 @@ on:
         required: false
         type: string
         default: 'src/helpers/schema.sql'
-      redis-version:
+      redis:
+        required: false
+        type: boolean
+        default: false
+      redis_version:
         required: false
         type: string
+        default: '7'
       dotenv_vars:
         required: false
         type: string
@@ -44,10 +49,10 @@ jobs:
           mysql -uroot -proot -e "FLUSH PRIVILEGES;"
 
       - name: Setup Redis
-        if: ${{ inputs.redis-version }}
+        if: ${{ inputs.redis }}
         uses: supercharge/redis-github-action@1.7.0
         with:
-          redis-version: ${{ inputs.redis-version }}
+          redis-version: ${{ inputs.redis_version }}
 
       - name: Yarn install
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
The current redis container for the test actions is not accessible by the test suite

See: https://github.com/snapshot-labs/snapshot-sequencer/actions/runs/6655771602/job/18086777780

It returns error

```
info: [redis-rl] Redis error connect ECONNREFUSED 127.0.0.1:6379 {"address":"127.0.0.1","code":"ECONNREFUSED","errno":-111,"port":6379,"stack":"Error: connect ECONNREFUSED 127.0.0.1:6379\n    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1278:16)","syscall":"connect"}
```

This PR migrates the redis setup to use [supercharge/redis-github-action](https://github.com/supercharge/redis-github-action)

Test are now able to connect to the redis instance: https://github.com/snapshot-labs/snapshot-sequencer/actions/runs/6662594759/job/18107166290#logs