### PR TITLE
Increase timeout for test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
[Tests in Stamp](https://github.com/stamp-labs/stamp/actions/runs/10281828057) are canceled due to this timeout. I find 2 minutes a little bit tight for larger test suites and GitHub's workflow runners can be a bit sluggish sometimes too.

I tried making it an input parameter but for some reason the workflow validation fails.

![image](https://github.com/user-attachments/assets/329dea1b-75ff-4614-9686-26afee37b44d)

No idea what I'm missing there.