### PR TITLE
feat: add psql support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,13 @@ on:
         required: false
         type: string
         default: 'src/helpers/schema.sql'
+      postgres_database_name:
+        required: false
+        type: string
+      postgres_schema_path:
+        required: false
+        type: string
+        default: 'src/helpers/schema.sql'
       redis:
         required: false
         type: boolean
@@ -47,6 +54,16 @@ jobs:
           mysql -uroot -proot ${{ inputs.mysql_database_name }} < ${{ inputs.mysql_schema_path }}
           mysql -uroot -proot -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';"
           mysql -uroot -proot -e "FLUSH PRIVILEGES;"
+
+      - name: Set up PostgreSQL
+        if: ${{ inputs.postgres_database_name }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql postgresql-contrib
+          sudo systemctl start postgresql.service
+          sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"
+          sudo -u postgres createdb ${{ inputs.postgres_database_name }}
+          sudo -u postgres psql -d ${{ inputs.postgres_database_name }} -f ${{ inputs.postgres_schema_path }}
 
       - name: Setup Redis
         if: ${{ inputs.redis }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/test.yml` to add support for setting up PostgreSQL databases during CI runs. It introduces new input parameters and a corresponding job step for PostgreSQL setup.

You can see it in actions here : https://github.com/snapshot-labs/brovider/actions/runs/15959598888/job/45010307311

