### PR TITLE
fix: replace redis action with direct docker run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,9 +67,7 @@ jobs:
 
       - name: Setup Redis
         if: ${{ inputs.redis }}
-        uses: supercharge/redis-github-action@1.7.0
-        with:
-          redis-version: ${{ inputs.redis_version }}
+        run: docker run -d --name redis -p 6379:6379 redis:${{ inputs.redis_version }}
 
       - name: Yarn install
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
## Summary
- Replace `supercharge/redis-github-action@1.7.0` with a direct `docker run` command
- The action runs Docker from inside its own container, causing a client API version mismatch on newer `ubuntu-latest` runners:
  ```
  docker: Error response from daemon: client version 1.40 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version.
  ```
- Using `docker run` directly from the host avoids this Docker-in-Docker version conflict

## Test plan
- [x] Verified the fix on snapshot-sequencer CI: https://github.com/snapshot-labs/snapshot-sequencer/actions/runs/21955485308/job/63418122681

🤖 Generated with [Claude Code](https://claude.com/claude-code)