### PR TITLE
feat: add Bun support via package_manager input

### DIFF
--- a/.github/workflows/create-sentry-release.yml
+++ b/.github/workflows/create-sentry-release.yml
@@ -41,7 +41,7 @@ jobs:
         run: ${{ inputs.package_manager }} install --frozen-lockfile
 
       - name: Build
-        run: ${{ inputs.package_manager }} build
+        run: ${{ inputs.package_manager }} run build
 
       - name: Create a Sentry release
         uses: getsentry/action-release@v1.4.1

--- a/.github/workflows/create-sentry-release.yml
+++ b/.github/workflows/create-sentry-release.yml
@@ -7,6 +7,10 @@ on:
         required: false
         default: '16'
         type: string
+      package_manager:
+        required: false
+        default: 'yarn'
+        type: string
       project:
         required: true
         type: string
@@ -23,16 +27,21 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Setup Bun
+        if: inputs.package_manager == 'bun'
+        uses: oven-sh/setup-bun@v2
+
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ inputs.target }}
-          cache: 'yarn'
+          cache: ${{ inputs.package_manager == 'yarn' && 'yarn' || '' }}
 
-      - name: Yarn install
-        run: yarn install --frozen-lockfile
+      - name: Install dependencies
+        run: ${{ inputs.package_manager }} install --frozen-lockfile
 
-      - name: Yarn build
-        run: yarn build
+      - name: Build
+        run: ${{ inputs.package_manager }} build
 
       - name: Create a Sentry release
         uses: getsentry/action-release@v1.4.1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,7 @@ jobs:
         run: ${{ inputs.package_manager }} install --frozen-lockfile
 
       - name: Lint
-        run: ${{ inputs.package_manager }} lint
+        run: ${{ inputs.package_manager }} run lint
 
       - name: Typecheck
-        run: ${{ inputs.package_manager }} typecheck
+        run: ${{ inputs.package_manager }} run typecheck

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,10 @@ on:
         required: false
         default: '18'
         type: string
+      package_manager:
+        required: false
+        default: 'yarn'
+        type: string
 
 jobs:
   lint:
@@ -16,16 +20,21 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Setup Bun
+        if: inputs.package_manager == 'bun'
+        uses: oven-sh/setup-bun@v2
+
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ inputs.target }}
-          cache: 'yarn'
+          cache: ${{ inputs.package_manager == 'yarn' && 'yarn' || '' }}
 
-      - name: Yarn install
-        run: yarn install --frozen-lockfile
+      - name: Install dependencies
+        run: ${{ inputs.package_manager }} install --frozen-lockfile
 
       - name: Lint
-        run: yarn lint
+        run: ${{ inputs.package_manager }} lint
 
       - name: Typecheck
-        run: yarn typecheck
+        run: ${{ inputs.package_manager }} typecheck

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -7,6 +7,10 @@ on:
         required: false
         default: '16'
         type: string
+      package_manager:
+        required: false
+        default: 'yarn'
+        type: string
 
 jobs:
   publish-npm:
@@ -15,15 +19,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Setup Bun
+        if: inputs.package_manager == 'bun'
+        uses: oven-sh/setup-bun@v2
+
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ inputs.target }}
           registry-url: https://registry.npmjs.org/
 
-      - name: Yarn install
-        run: yarn install --frozen-lockfile
+      - name: Install dependencies
+        run: ${{ inputs.package_manager }} install --frozen-lockfile
 
       - name: Publish to NPM
-        run: yarn publish
+        run: ${{ inputs.package_manager }} publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,10 @@ on:
         required: false
         type: string
         default: '16'
+      package_manager:
+        required: false
+        type: string
+        default: 'yarn'
       mysql_database_name:
         required: false
         type: string
@@ -41,10 +45,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Setup Bun
+        if: inputs.package_manager == 'bun'
+        uses: oven-sh/setup-bun@v2
+
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ inputs.target }}
-          cache: 'yarn'
+          cache: ${{ inputs.package_manager == 'yarn' && 'yarn' || '' }}
 
       - name: Set up MySQL
         if: ${{ inputs.mysql_database_name }}
@@ -69,15 +78,15 @@ jobs:
         if: ${{ inputs.redis }}
         run: docker run -d --name redis -p 6379:6379 redis:${{ inputs.redis_version }}
 
-      - name: Yarn install
-        run: yarn install --frozen-lockfile
+      - name: Install dependencies
+        run: ${{ inputs.package_manager }} install --frozen-lockfile
 
       - name: Setup test environment variables
         if: ${{ inputs.dotenv_vars }}
         run: echo -e "\n${{ inputs.dotenv_vars }}" >> test/.env.test
 
       - name: Test
-        run: yarn test
+        run: ${{ inputs.package_manager }} test
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
         run: echo -e "\n${{ inputs.dotenv_vars }}" >> test/.env.test
 
       - name: Test
-        run: ${{ inputs.package_manager }} test
+        run: ${{ inputs.package_manager }} run test
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/README.md
+++ b/README.md
@@ -188,6 +188,19 @@ jobs:
       target: ${{ matrix.target }}
 ```
 
+## Using Bun instead of Yarn
+
+The `lint`, `test`, `create-sentry-release` and `publish-npm` workflows accept a `package_manager` input that can be set to `bun` (default is `yarn`). When set to `bun`, the workflow installs Bun, runs `bun install --frozen-lockfile`, and invokes the project's scripts via `bun` instead of `yarn`. A `bun.lock` must be committed to the repo.
+
+```yaml
+jobs:
+  lint:
+    uses: snapshot-labs/actions/.github/workflows/lint.yml@main
+    secrets: inherit
+    with:
+      package_manager: bun
+```
+
 ## Convention
 
 - Workflows are following the `VERB-DESCRIPTION` convention (e.g. `lint`, `build`, `publish-npm`) 


### PR DESCRIPTION
## Summary

- Adds a `package_manager` input (default `yarn`, accepts `bun`) to the `lint`, `test`, `create-sentry-release`, and `publish-npm` reusable workflows.
- When set to `bun`, the workflow installs Bun via `oven-sh/setup-bun@v2`, runs `bun install --frozen-lockfile`, and invokes scripts (`lint`, `typecheck`, `test`, `build`, `publish`) through `bun` instead of `yarn`.
- Existing consumers keep their current behavior — no change required.
- README updated with a "Using Bun instead of Yarn" section.

## Why opt-in vs hard switch

These workflows are shared across many snapshot-labs repos. A hard yarn→bun switch would break every consumer at once and force a coordinated migration. The opt-in approach lets each repo migrate at its own pace, with `snapshot-hub` as the first opt-in. Once all consumers have migrated, we can flip the default and eventually remove yarn support.

If you'd rather hard-switch, let me know and I'll redo the PR.

## Test plan

- [ ] Test the lint workflow with `package_manager: bun` from a consumer repo (snapshot-hub).
- [ ] Test the test workflow with `package_manager: bun` from a consumer repo.
- [ ] Test the create-sentry-release workflow with `package_manager: bun`.
- [ ] Confirm existing consumers (default `yarn`) still pass CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)