### PR TITLE
feat: add working_directory input to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,10 @@ on:
       dotenv_vars:
         required: false
         type: string
+      working_directory:
+        required: false
+        type: string
+        default: '.'
 
 jobs:
   test:
@@ -57,6 +61,7 @@ jobs:
 
       - name: Set up MySQL
         if: ${{ inputs.mysql_database_name }}
+        working-directory: ${{ inputs.working_directory }}
         run: |
           sudo /etc/init.d/mysql start
           mysql -e 'CREATE DATABASE ${{ inputs.mysql_database_name }};' -uroot -proot
@@ -66,6 +71,7 @@ jobs:
 
       - name: Set up PostgreSQL
         if: ${{ inputs.postgres_database_name }}
+        working-directory: ${{ inputs.working_directory }}
         run: |
           sudo apt-get update
           sudo apt-get install -y postgresql postgresql-contrib
@@ -79,13 +85,16 @@ jobs:
         run: docker run -d --name redis -p 6379:6379 redis:${{ inputs.redis_version }}
 
       - name: Install dependencies
+        working-directory: ${{ inputs.working_directory }}
         run: ${{ inputs.package_manager }} install --frozen-lockfile
 
       - name: Setup test environment variables
         if: ${{ inputs.dotenv_vars }}
+        working-directory: ${{ inputs.working_directory }}
         run: echo -e "\n${{ inputs.dotenv_vars }}" >> test/.env.test
 
       - name: Test
+        working-directory: ${{ inputs.working_directory }}
         run: ${{ inputs.package_manager }} run test
 
       - name: Upload coverage reports to Codecov


### PR DESCRIPTION
## Summary

Adds an optional `working_directory` input (defaults to `'.'`) that scopes the run-script steps (MySQL setup, Postgres setup, install, `.env.test` write, test) to a subdirectory. Schema path inputs resolve relative to it.

Backward-compatible: with the default, existing callers see no behavior change.

Motivated by [snapshot-labs/sx-monorepo#2078](https://github.com/snapshot-labs/sx-monorepo/pull/2078), which moves snapshot-hub into the monorepo at `apps/hub`. The new `apps/hub/.github/workflows/hub-test.yml` calls this reusable workflow with `working_directory: apps/hub`.

## Test plan

- [x] Default (`working_directory: '.'`) preserves existing behavior on every existing caller
- [ ] sx-monorepo's `hub-test.yml` provisions MySQL with `apps/hub/src/helpers/schema.sql`, runs `bun install` and `bun run test` from `apps/hub`, all green

## Notes

- `working-directory:` is a `run`-step-only setting; `uses:` actions like `actions/checkout`, `actions/setup-node`, `oven-sh/setup-bun`, and `codecov/codecov-action` are unaffected.
- Codecov defaults to discovering coverage at the repo root. Callers using a subdirectory may need to configure codecov separately if their coverage output lives there — that's left for a follow-up rather than coupling it to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)