### PR TITLE
chore: bump CI actions off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           tag_name: ${{ inputs.tag_name }}

--- a/.github/workflows/create-sentry-release.yml
+++ b/.github/workflows/create-sentry-release.yml
@@ -26,13 +26,13 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       - name: Setup Bun
         if: inputs.package_manager == 'bun'
         uses: oven-sh/setup-bun@v2
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.target }}
           cache: ${{ inputs.package_manager == 'yarn' && 'yarn' || '' }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,13 +19,13 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       - name: Setup Bun
         if: inputs.package_manager == 'bun'
         uses: oven-sh/setup-bun@v2
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.target }}
           cache: ${{ inputs.package_manager == 'yarn' && 'yarn' || '' }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -18,13 +18,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       - name: Setup Bun
         if: inputs.package_manager == 'bun'
         uses: oven-sh/setup-bun@v2
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.target }}
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,13 +48,13 @@ jobs:
     timeout-minutes: 2
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       - name: Setup Bun
         if: inputs.package_manager == 'bun'
         uses: oven-sh/setup-bun@v2
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.target }}
           cache: ${{ inputs.package_manager == 'yarn' && 'yarn' || '' }}
@@ -98,6 +98,6 @@ jobs:
         run: ${{ inputs.package_manager }} run test
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
> [!IMPORTANT]
> **On merge:** close snapshot-labs/sx-monorepo#2193 (temp validation PR, do not merge it — `@main` auto-picks up this fix).

GitHub runners deprecated Node 20 ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)); v3 actions are force-run on Node 24 with a warning. Bumps every workflow off deprecated Node runtimes (Node 20 and an older Node 16).

**`test.yml`**
- `actions/checkout` v3 → v7
- `actions/setup-node` v3 → v6
- `codecov/codecov-action` v3 → v7

**`lint.yml`, `publish-npm.yml`, `create-sentry-release.yml`**
- `actions/checkout` v3 → v7
- `actions/setup-node` v3 → v6

**`create-github-release.yml`**
- `actions/checkout` v3 → v7
- `softprops/action-gh-release` v1 (node16) → v3 (node24)

Notes:
- checkout/setup-node `@v4` still target Node 20 — need v5+ for Node 24, so v4 wouldn't clear the warning.
- codecov v5+ and the bumped actions only use args this repo already passes (`token`, `node-version`, `generate_release_notes`, `tag_name`) — no renamed/removed args in play.
- `getsentry/action-release` left as-is: docker action, no Node runtime, not deprecated.
- `oven-sh/setup-bun@v2` unaffected.

Validated by snapshot-labs/sx-monorepo#2193 (temporarily points its reusable-workflow ref at this branch).