### PR TITLE
fix: allow skipping postgres schema import

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,9 +78,9 @@ jobs:
           sudo systemctl start postgresql.service
           sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"
           sudo -u postgres createdb ${{ inputs.postgres_database_name }}
-          if [ -n "${{ inputs.postgres_schema_path }}" ]; then
-            sudo -u postgres psql -d ${{ inputs.postgres_database_name }} -f ${{ inputs.postgres_schema_path }}
-          fi
+if [[ -n "${{ inputs.postgres_schema_path }}" ]]; then
+  sudo -u postgres psql -d "${{ inputs.postgres_database_name }}" -f "${{ inputs.postgres_schema_path }}"
+fi
 
       - name: Setup Redis
         if: ${{ inputs.redis }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,9 @@ jobs:
           sudo systemctl start postgresql.service
           sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"
           sudo -u postgres createdb ${{ inputs.postgres_database_name }}
-          sudo -u postgres psql -d ${{ inputs.postgres_database_name }} -f ${{ inputs.postgres_schema_path }}
+          if [ -n "${{ inputs.postgres_schema_path }}" ]; then
+            sudo -u postgres psql -d ${{ inputs.postgres_database_name }} -f ${{ inputs.postgres_schema_path }}
+          fi
 
       - name: Setup Redis
         if: ${{ inputs.redis }}


### PR DESCRIPTION
Set `postgres_schema_path: ''` to skip the schema import step.

- Empty string skips `psql -f`; default (`src/helpers/schema.sql`) unchanged, existing callers unaffected.
- Checked all org callers: none use postgres inputs yet, so no CI impact.