### PR TITLE
fix: restore indentation of postgres schema import block

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,9 +78,9 @@ jobs:
           sudo systemctl start postgresql.service
           sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"
           sudo -u postgres createdb ${{ inputs.postgres_database_name }}
-if [[ -n "${{ inputs.postgres_schema_path }}" ]]; then
-  sudo -u postgres psql -d "${{ inputs.postgres_database_name }}" -f "${{ inputs.postgres_schema_path }}"
-fi
+          if [[ -n "${{ inputs.postgres_schema_path }}" ]]; then
+            sudo -u postgres psql -d "${{ inputs.postgres_database_name }}" -f "${{ inputs.postgres_schema_path }}"
+          fi
 
       - name: Setup Redis
         if: ${{ inputs.redis }}


### PR DESCRIPTION
Fixes indentation of the `if`/`fi` block introduced in #25 — lines were flush-left instead of indented inside the `run:` block.